### PR TITLE
Fix rendering issue with Aikoyori's Shenanigans' font config

### DIFF
--- a/lib/fixes.lua
+++ b/lib/fixes.lua
@@ -207,7 +207,11 @@ end
 function UIElement:update_text()
   if self.config and self.config.text and not self.config.text_drawable then
       self.config.lang = self.config.lang or G.LANG
-      self.config.text_drawable = love.graphics.newText(self.config.lang.font.FONT, {G.C.WHITE,self.config.text})
+	  if self.config.font then
+        self.config.text_drawable = love.graphics.newText(self.config.font.FONT, {G.C.WHITE,self.config.text})
+      else
+		self.config.text_drawable = love.graphics.newText(self.config.lang.font.FONT, {G.C.WHITE,self.config.text})
+	  end
   end
 
   if self.config.ref_table and self.config.ref_table[self.config.ref_value] ~= self.config.prev_value then

--- a/lib/fixes.lua
+++ b/lib/fixes.lua
@@ -209,8 +209,8 @@ function UIElement:update_text()
       self.config.lang = self.config.lang or G.LANG
 	  if self.config.font then
         self.config.text_drawable = love.graphics.newText(self.config.font.FONT, {G.C.WHITE,self.config.text})
-      else
-		self.config.text_drawable = love.graphics.newText(self.config.lang.font.FONT, {G.C.WHITE,self.config.text})
+	  else
+	    self.config.text_drawable = love.graphics.newText(self.config.lang.font.FONT, {G.C.WHITE,self.config.text})
 	  end
   end
 


### PR DESCRIPTION
Aikoyori's Shenanigans uses a custom font feature for defining custom fonts to use in text descriptions.

As of the latest commit, having Entropy on breaks this, making the description look like this instead:

![image](https://github.com/user-attachments/assets/771dee6d-41aa-4eee-a3f6-f3075c6592ee)

This pull request fixes this issue by adding the font check that Entropy omits due to it overriding `UIElement:update_text()` entirely.

![image](https://github.com/user-attachments/assets/164132d1-623b-45ad-9517-621a51968572)

