### PR TITLE
fix SMODS.get_blind_amount hook when blind amount isn't bignum

### DIFF
--- a/lib/fixes.lua
+++ b/lib/fixes.lua
@@ -185,7 +185,7 @@ function SMODS.get_blind_amount(ante)
     local a, b, c, d = amounts[8], amounts[8]/amounts[7], ante-8, 1 + 0.2*(ante-8)
     local amount = math.floor(a*(b + (b*k*c)^d)^c)
     if ( to_big(amount) < to_big(R and R.E_MAX_SAFE_INTEGER or 9e15)) then
-	  local amount_log = type(amount) == "table" and amount:log10() or math.log10(amount) end
+	  local amount_log = type(amount) == "table" and amount:log10() or math.log10(amount)
       local exponent = to_big(10)^(math.floor(amount_log - to_big(1)))
 	  if type(exponent) == "table" then exponent = exponent:to_number() end
       amount = math.floor(amount / exponent)


### PR DESCRIPTION
add some extra checks so that stuff like amount:log10() and exponent:to_number() aren't automatically called on non-bignum values

also i mildly messed up creating the fork so there's a few junk commits in here sorry