### PR TITLE
fix the rlegendary outline skipping part of its animation if it is on screen at exactly 5000 seconds after the game started running, and every 5000 seconds thereafter

### DIFF
--- a/items/jokers/rlegendary_jokers.lua
+++ b/items/jokers/rlegendary_jokers.lua
@@ -717,7 +717,7 @@ SMODS.Shader{
     send_vars = function()
         local t = G.TIMERS.REAL or 0
         local grad = Entropy.current_rlegendary_gradient or Entropy.reverse_legendary_gradient
-        t = t - 5000*math.floor(t/5000)
+        t = t % math.pi
         return {
             realtime = t,
             outline_color = {


### PR DESCRIPTION
yea